### PR TITLE
WIP: Switch to thewtex/centos-build:v1.0.0 base for Slicer compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,39 @@
-FROM dockcross/base:latest
-MAINTAINER Matt McCormick <matt.mccormick@kitware.com>
+FROM thewtex/centos-build:v1.0.0
+MAINTAINER Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
 
-ENV DEFAULT_DOCKCROSS_IMAGE thewtex/opengl
-
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  git \
-  libgl1-mesa-dri \
-  menu \
+RUN yum update -y && \
+  yum install -y \
+  mesa-libGL \
   net-tools \
-  openbox \
-  python-pip \
   sudo \
-  supervisor \
-  tint2 \
-  x11-xserver-utils \
-  x11vnc \
-  xinit \
-  xserver-xorg-video-dummy \
-  xserver-xorg-input-void \
-  websockify && \
-  rm -f /usr/share/applications/x11vnc.desktop && \
-  pip install supervisor-stdout && \
-  apt-get -y clean
+  xorg-x11-server-utils \
+  xorg-x11-server-Xvnc-source \
+  xorg-x11-xinit \
+  xorg-x11-drv-dummy \
+  xorg-x11-drv-void
+
+RUN wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py && \
+  python get-pip.py
+
+RUN rm -f /usr/share/applications/x11vnc.desktop && \
+  pip install websockify supervisor supervisor-stdout && \
+  mkdir /var/log/supervisor/
+
+# Following package are required for building x11vnc
+RUN yum install -y \
+  libjpeg-devel \
+  libXcursor-devel \
+  libXinerama-devel \
+  libXrandr-devel \
+  libXt-devel \
+  libXtst-devel
+
+RUN wget "http://downloads.sourceforge.net/project/libvncserver/x11vnc/0.9.13/x11vnc-0.9.13.tar.gz?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Flibvncserver%2Ffiles%2Fx11vnc%2F0.9.13%2F&ts=1475558391&use_mirror=heanet" && \
+  tar -xzvf x11vnc-0.9.13.tar.gz && \
+  cd x11vnc-0.9.13 && \
+  ./configure && \
+  make -j8 && \
+  make install
 
 COPY etc/skel/.xinitrc /etc/skel/.xinitrc
 
@@ -30,13 +42,27 @@ USER user
 
 RUN cp /etc/skel/.xinitrc /home/user/
 USER root
-RUN echo "user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user
-
+RUN echo "user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers
 
 RUN git clone https://github.com/kanaka/noVNC.git /opt/noVNC && \
   cd /opt/noVNC && \
   git checkout 6a90803feb124791960e3962e328aa3cfb729aeb && \
   ln -s vnc_auto.html index.html
+
+# Install OpenBox
+RUN wget ftp://ftp.pbone.net/mirror/centos.karan.org/el5/extras/testing/x86_64/RPMS/openbox-libs-3.4.7.2-5.el5.kb.x86_64.rpm && \
+  wget ftp://ftp.pbone.net/mirror/centos.karan.org/el5/extras/testing/x86_64/RPMS/openbox-3.4.7.2-5.el5.kb.x86_64.rpm && \
+  yum install --nogpgcheck -y openbox*.rpm
+
+# Following package are required for building x11vnc
+RUN yum install -y \
+  mesa-libGLU
+
+RUN cd x11vnc-0.9.13 && \
+  ./x11vnc/misc/Xdummy && \
+  ./x11vnc/misc/Xdummy -install && \
+  cp ./x11vnc/misc/Xdummy /usr/local/bin/ && \
+  cp ./x11vnc/misc/Xdummy.so /usr/local/bin/
 
 # noVNC (http server) is on 6080, and the VNC server is on 5900
 EXPOSE 6080 5900
@@ -47,4 +73,5 @@ COPY usr /usr
 ENV DISPLAY :0
 
 WORKDIR /root
-CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]
+
+CMD ["/usr/local/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 
 script_dir="`cd $(dirname $0); pwd`"
 
-docker build -t thewtex/opengl $script_dir
+docker build -t slicer/opengl $script_dir

--- a/etc/skel/.xinitrc
+++ b/etc/skel/.xinitrc
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 xsetroot -solid "#333333"
-(sleep 2s && tint2 -c /etc/xdg/tint2/tint2rc) &
+#(sleep 2s && tint2 -c /etc/xdg/tint2/tint2rc) &
 openbox

--- a/etc/supervisor/conf.d/xdummy.conf
+++ b/etc/supervisor/conf.d/xdummy.conf
@@ -1,5 +1,5 @@
 [program:xdummy]
-command=bash -l -c "xinit -- :0 -nolisten tcp vt$XDG_VTNR -noreset +extension GLX +extension RANDR +extension RENDER +extension XFIXES"
+command=bash -l -c "Xdummy :0 -nolisten tcp vt$XDG_VTNR -noreset +extension GLX +extension RANDR +extension RENDER +extension XFIXES"
 user=user
 environment=HOME=/home/user,USER=user,QT_X11_NO_MITSHM=1
 directory=/home/user

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,7 +1,7 @@
-FROM thewtex/opengl:latest
+FROM slicer/opengl:latest
 MAINTAINER Matt McCormick <matt.mccormick@kitware.com>
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  mesa-utils
+RUN yum update -y && \
+  yum install -y glx-utils
 
 ENV APP "glxgears"

--- a/example/build.sh
+++ b/example/build.sh
@@ -2,4 +2,4 @@
 
 script_dir="`cd $(dirname $0); pwd`"
 
-docker build -t thewtex/opengl-example $script_dir
+docker build -t slicer/opengl-example $script_dir

--- a/example/run.sh
+++ b/example/run.sh
@@ -2,4 +2,4 @@
 
 script_dir="`cd $(dirname $0); pwd`"
 
-$script_dir/../run.sh -c opengl-example -i thewtex/opengl-example -p 6081 "$@"
+$script_dir/../run.sh -c opengl-example -i slicer/opengl-example -p 6081 "$@"

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 container=opengl
-image=thewtex/opengl
+image=slicer/opengl
 port=6080
 extra_run_args=""
 quiet=""


### PR DESCRIPTION
### Running slicer using `thewtex/docker-opengl` based of `debian:jessie`

Trying to run the binaries built in `slicer/slicer-build` image from within the `thewtex/docker-opengl` fails with the following error:

```
X Error: BadDrawable (invalid Pixmap or Window parameter) 9
  Major opcode: 62 (X_CopyArea)
  Resource id:  0x800077
X Error: BadAccess (attempt to access private resource denied) 10
  Extension:    130 (MIT-SHM)
  Minor opcode: 1 (X_ShmAttach)
  Resource id:  0x12e
```

Note: To workaround this error:

```
/home/user/work/./bin/SlicerApp-real: error while loading shared libraries: libGLU.so.1: cannot open shared object file: No such file or directory
```

I apply this patch:

```diff
$ git diff
diff --git a/Dockerfile b/Dockerfile
index de109dc..b2af7e4 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   xinit \
   xserver-xorg-video-dummy \
   xserver-xorg-input-void \
-  websockify && \
+  websockify \
+  libglu1-mesa-dev && \
   rm -f /usr/share/applications/x11vnc.desktop && \
   pip install supervisor-stdout && \
   apt-get -y clean
```

### This PR: Update `docker-opengl` to use `centos-build:v1.0.0` as a base

What motivates this experiment is to find way of running test associated with SlicerDocker build without having to rebuild Slicer from scratch just for testing ...

With this set of changes, I was able to interact with Slicer built by https://github.com/thewtex/SlicerDocker


```
cd /tmp/Slicer-4.5.0-0000-00-00-linux-amd64
~/Projects/docker-opengl/run.sh -r --env="APP=/home/user/work/Slicer"
```

![screenshot from 2016-10-04 11-12-02](https://cloud.githubusercontent.com/assets/219043/19079957/6cec9fe4-8a23-11e6-95b3-d58d5fbb3b20.png)





Note: To work around the missing QtTest lib, in addition of copying the linux package, I add to manually copy the file:

```
docker cp e82e94fa57a2:/usr/src/Slicer-build/Slicer-build/Slicer-4.5.0-0000-00-00-linux-amd64.tar.gz /tmp/Slicer-4.5.0-0000-00-00-linux-amd64.tar.gz
cd tmp
aunpack Slicer-4.5.0-0000-00-00-linux-amd64.tar.gz
cd Slicer-4.5.0-0000-00-00-linux-amd64
docker cp e82e94fa57a2:/usr/src/qt-everywhere-opensource-release-src-4.8.7/lib/libQtTest.so.4.8.7 ./lib/Slicer-4.5/libQtTest.so.4.8.7
```

Moving forward:

* the version of X used in `centos-build:v1.0.0`  is ancient, we could build a newer version in `docker-opengl`, that should help to address performance issue related to x11vnc and may be it could help get rid of http://www.karlrunge.com/x11vnc/Xdummy