### PR TITLE
ENH: Creation of a centos version of docker-opengl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,39 @@
-FROM dockcross/base:latest
-MAINTAINER Matt McCormick <matt.mccormick@kitware.com>
+FROM thewtex/centos-build:v1.0.0
+MAINTAINER Mayeul Chassagnard <mayeul.chassagnard@kitware.com> Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
 
-ENV DEFAULT_DOCKCROSS_IMAGE thewtex/opengl
-
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  git \
-  libgl1-mesa-dri \
-  menu \
+RUN yum update -y && \
+  yum install -y \
+  mesa-libGL \
   net-tools \
-  openbox \
-  python-pip \
   sudo \
-  supervisor \
-  tint2 \
-  x11-xserver-utils \
-  x11vnc \
-  xinit \
-  xserver-xorg-video-dummy \
-  xserver-xorg-input-void \
-  websockify && \
-  rm -f /usr/share/applications/x11vnc.desktop && \
-  pip install supervisor-stdout && \
-  apt-get -y clean
+  xorg-x11-server-utils \
+  xorg-x11-server-Xvnc-source \
+  xorg-x11-xinit \
+  xorg-x11-drv-dummy \
+  xorg-x11-drv-void
+
+RUN wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py && \
+  python get-pip.py
+
+RUN rm -f /usr/share/applications/x11vnc.desktop && \
+  pip install websockify supervisor supervisor-stdout && \
+  mkdir /var/log/supervisor/
+
+# Following package are required for building x11vnc
+RUN yum install -y \
+  libjpeg-devel \
+  libXcursor-devel \
+  libXinerama-devel \
+  libXrandr-devel \
+  libXt-devel \
+  libXtst-devel
+
+RUN wget "http://downloads.sourceforge.net/project/libvncserver/x11vnc/0.9.13/x11vnc-0.9.13.tar.gz?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Flibvncserver%2Ffiles%2Fx11vnc%2F0.9.13%2F&ts=1475558391&use_mirror=heanet" && \
+  tar -xzvf x11vnc-0.9.13.tar.gz && \
+  cd x11vnc-0.9.13 && \
+  ./configure && \
+  make -j8 && \
+  make install
 
 COPY etc/skel/.xinitrc /etc/skel/.xinitrc
 
@@ -30,13 +42,88 @@ USER user
 
 RUN cp /etc/skel/.xinitrc /home/user/
 USER root
-RUN echo "user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user
-
+RUN echo "user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers
 
 RUN git clone https://github.com/kanaka/noVNC.git /opt/noVNC && \
   cd /opt/noVNC && \
   git checkout 6a90803feb124791960e3962e328aa3cfb729aeb && \
   ln -s vnc_auto.html index.html
+
+# Install OpenBox
+RUN wget ftp://ftp.pbone.net/mirror/centos.karan.org/el5/extras/testing/x86_64/RPMS/openbox-libs-3.4.7.2-5.el5.kb.x86_64.rpm && \
+  wget ftp://ftp.pbone.net/mirror/centos.karan.org/el5/extras/testing/x86_64/RPMS/openbox-3.4.7.2-5.el5.kb.x86_64.rpm && \
+  yum install --nogpgcheck -y openbox*.rpm
+
+# Following package are required for building x11vnc
+RUN yum install -y \
+  mesa-libGLU
+
+RUN cd x11vnc-0.9.13 && \
+  ./x11vnc/misc/Xdummy && \
+  ./x11vnc/misc/Xdummy -install && \
+  cp ./x11vnc/misc/Xdummy /usr/local/bin/ && \
+  cp ./x11vnc/misc/Xdummy.so /usr/local/bin/
+
+
+###############################################
+# Pre-requisites to build the X_Window_System #
+###############################################
+
+WORKDIR /root
+
+RUN yum install -y \
+  ack-grep \
+  vim
+
+RUN curl http://beyondgrep.com/ack-2.12-single-file > /bin/ack && chmod 0755 /bin/ack
+
+# Update to autoconf-2.69
+RUN wget --no-check-certificate http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz && \
+  tar xvfvz autoconf-2.69.tar.gz && \
+  cd autoconf-2.69 && \
+  ./configure && \
+  make && \
+  make install
+
+# install libtool 2.4.6
+RUN yum erase -y libtool && \
+  wget --no-check-certificate http://ftpmirror.gnu.org/libtool/libtool-2.4.6.tar.gz && \
+  tar -xzvf libtool-2.4.6.tar.gz && \
+  cd libtool-2.4.6 && \
+  ./configure && \
+  make && \
+  make install
+
+
+###########################################
+# Building_the_X_Window_System for centOS #
+###########################################
+#
+# https://www.x.org/wiki/Building_the_X_Window_System/#buildprocessbasedonbuild.shscript
+#
+
+WORKDIR /root
+
+RUN mkdir src && \
+  git clone git://anongit.freedesktop.org/git/xorg/util/modular src/util/modular && \
+  mkdir build
+
+# XXX This hack is required to ensure autoconf can find libtool macros.
+# Without it the following error was reported during the building of lib/libXau :
+#  configure.ac:35: error: possibly undefined macro: AC_LIBTOOL_WIN32_DLL
+#      If this token and others are legitimate, please use m4_pattern_allow.
+#      See the Autoconf documentation.
+#  configure.ac:36: error: possibly undefined macro: AC_PROG_LIBTOOL
+RUN mkdir -p build/share && \
+  cd build/share/ && \
+  ln -s /usr/local/share/aclocal/ aclocal
+
+# Install the newer version of X11 ::: Still an error during lib/libx11
+#RUN cd src && \
+#  ./util/modular/build.sh --clone $HOME/build
+
+###########################################
+###########################################
 
 # noVNC (http server) is on 6080, and the VNC server is on 5900
 EXPOSE 6080 5900
@@ -47,4 +134,5 @@ COPY usr /usr
 ENV DISPLAY :0
 
 WORKDIR /root
-CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]
+
+CMD ["/usr/local/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,6 @@
-docker-opengl
+docker-opengl:centOS
 =============
-A docker image that supports rendering graphical applications, including OpenGL apps.
-
-.. image:: https://circleci.com/gh/thewtex/docker-opengl.svg?style=svg
-    :target: https://circleci.com/gh/thewtex/docker-opengl
-
-.. image:: https://badge.imagelayers.io/thewtex/opengl:latest.svg
-  :target: https://imagelayers.io/?images=thewtex/opengl:latest
+A docker image based on centOS 5 that supports rendering graphical applications, including OpenGL apps.
 
 Overview
 --------

--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 
 script_dir="`cd $(dirname $0); pwd`"
 
-docker build -t thewtex/opengl $script_dir
+docker build -t thewtex/opengl:centos-2016.10.20 $script_dir

--- a/circle.yml
+++ b/circle.yml
@@ -5,10 +5,8 @@ machine:
 dependencies:
   override:
     - docker info
-    - docker pull thewtex/opengl
-    - docker pull thewtex/opengl-example
+    - docker pull thewtex/centos-build:v1.0.0
 
 test:
   override:
     - ~/docker-opengl/build.sh
-    - ~/docker-opengl/example/build.sh

--- a/etc/skel/.xinitrc
+++ b/etc/skel/.xinitrc
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 xsetroot -solid "#333333"
-(sleep 2s && tint2 -c /etc/xdg/tint2/tint2rc) &
+#(sleep 2s && tint2 -c /etc/xdg/tint2/tint2rc) &
 openbox

--- a/etc/supervisor/conf.d/xdummy.conf
+++ b/etc/supervisor/conf.d/xdummy.conf
@@ -1,5 +1,5 @@
 [program:xdummy]
-command=bash -l -c "xinit -- :0 -nolisten tcp vt$XDG_VTNR -noreset +extension GLX +extension RANDR +extension RENDER +extension XFIXES"
+command=bash -l -c "Xdummy :0 -nolisten tcp vt$XDG_VTNR -noreset +extension GLX +extension RANDR +extension RENDER +extension XFIXES"
 user=user
 environment=HOME=/home/user,USER=user,QT_X11_NO_MITSHM=1
 directory=/home/user

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,7 +1,7 @@
-FROM thewtex/opengl:latest
+FROM slicer/opengl:latest
 MAINTAINER Matt McCormick <matt.mccormick@kitware.com>
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  mesa-utils
+RUN yum update -y && \
+  yum install -y glx-utils
 
 ENV APP "glxgears"

--- a/example/build.sh
+++ b/example/build.sh
@@ -2,4 +2,4 @@
 
 script_dir="`cd $(dirname $0); pwd`"
 
-docker build -t thewtex/opengl-example $script_dir
+docker build -t slicer/opengl-example $script_dir

--- a/example/run.sh
+++ b/example/run.sh
@@ -2,4 +2,4 @@
 
 script_dir="`cd $(dirname $0); pwd`"
 
-$script_dir/../run.sh -c opengl-example -i thewtex/opengl-example -p 6081 "$@"
+$script_dir/../run.sh -c opengl-example -i slicer/opengl-example -p 6081 "$@"

--- a/push.sh
+++ b/push.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+script_dir="`cd $(dirname $0); pwd`"
+
+docker push thewtex/opengl:centos-2016.10.20

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 container=opengl
-image=thewtex/opengl
+image=thewtex/opengl:centos-2016.10.20
 port=6080
 extra_run_args=""
 quiet=""


### PR DESCRIPTION
This useful image have been created to be used for Slicer CI.

Because the slicer build tree docker image (slicer/slicer-build) is based
on centos 5, then we have to run the tests on centos 5 if we don't want to
rebuild everything and just share the volume which contains the build tree.

CC: @thewtex 