### PR TITLE
Fix "stdout event buffer overflowed" errors related to supervisor "eventlistener" plugin

### DIFF
--- a/etc/supervisor/conf.d/graphical-app-launcher.conf
+++ b/etc/supervisor/conf.d/graphical-app-launcher.conf
@@ -12,6 +12,6 @@ stderr_events_enabled = true
 
 [eventlistener:stdout]
 command = supervisor_stdout
-buffer_size = 100
+buffer_size = 1024
 events = PROCESS_LOG
 result_handler = supervisor_stdout:event_handler


### PR DESCRIPTION
Fix "stdout event buffer overflowed" errors related to supervisor "eventlistener" plugin
    
While attempting to address error, a value greater than 100 was chosen and
1024 seems a reasonable choice.
    
This commit addresses errors like the following:

```    
2018-06-04 15:41:27,062 ERRO pool stdout event buffer overflowed, discarding event 0
2018-06-04 15:41:27,062 ERRO pool stdout event buffer overflowed, discarding event 1
[...]
```